### PR TITLE
Fix indentation on theme check else statement

### DIFF
--- a/trunk/planet/config.py
+++ b/trunk/planet/config.py
@@ -183,8 +183,8 @@ def load(config_files):
                 parser.set('Planet', 'template_files',
                    ' '.join(template_files + config.template_files()))
                 break
-        else:
-            log.error('Unable to find theme %s', theme)
+    else:
+        log.error('Unable to find theme %s', theme)
 
     # Filter support
     dirs = config.filter_directories()


### PR DESCRIPTION
The indentation was wrong on the if config / else statement, leading it to always alert that there was an error finding the theme and causing me lots of wasted time.